### PR TITLE
Undo & Redo 기능 구현

### DIFF
--- a/web/src/features/editor/Editor.tsx
+++ b/web/src/features/editor/Editor.tsx
@@ -22,7 +22,7 @@ const Editor: React.FC = () => {
     if (!fileEntryId) return
     loadFileEntry({ variables: { id: fileEntryId } })
     if (!history) initialize(fileEntryId)
-  }, [loadFileEntry, fileEntryId, initialize])
+  }, [loadFileEntry, fileEntryId, initialize, history])
 
   useEffect(() => {
     console.log(history)
@@ -93,7 +93,7 @@ const Editor: React.FC = () => {
         recordDrawing(fileEntryId, layerRef.current?.toDataURL({})!)
       }
     },
-    [fileEntryId]
+    [fileEntryId, recordDrawing]
   )
 
   function zoom(e: WheelEvent) {

--- a/web/src/features/editor/Editor.tsx
+++ b/web/src/features/editor/Editor.tsx
@@ -123,11 +123,15 @@ const Editor: React.FC = () => {
 
   const stopDrawing = useCallback(
     (e: KonvaEventObject<MouseEvent>) => {
-      setIsDrawing(false)
+      if (!fileEntryId) return
 
-      if (fileEntryId && e.evt.type === 'mouseup') {
+      if (
+        e.evt.type === 'mouseup' ||
+        (e.evt.type === 'mouseout' && e.evt.buttons === 1)
+      ) {
         recordDrawing(fileEntryId, lastLine.current?.toObject().attrs)
       }
+      setIsDrawing(false)
     },
     [fileEntryId, recordDrawing]
   )

--- a/web/src/features/menu-bar/components/EditorMenu.tsx
+++ b/web/src/features/menu-bar/components/EditorMenu.tsx
@@ -3,12 +3,13 @@ import { jsx, css } from '@emotion/core'
 import { MdBrush, MdUndo, MdRedo, MdTranslate } from 'react-icons/md'
 import { FaEraser } from 'react-icons/fa'
 import { useEditor, useEditorState } from '~/store/modules/editor'
-import { useHistory } from '~/store/modules/history'
+import { useHistory, useHistoryState } from '~/store/modules/history'
 
 const EditorMenu: React.FC = () => {
   const editor = useEditor()
   const { fileEntryId } = useEditorState()
   const history = useHistory()
+  const historyState = useHistoryState(fileEntryId)
 
   return (
     <div css={styles.editorMenu}>
@@ -24,14 +25,20 @@ const EditorMenu: React.FC = () => {
       />
       <MdTranslate css={styles.icon} size={24} />
       <MdUndo
-        css={styles.icon}
+        css={[
+          styles.icon,
+          ...(!historyState?.past.length ? [styles.disabled] : []),
+        ]}
         size={24}
         onClick={() => {
           if (fileEntryId) history.undo(fileEntryId)
         }}
       />
       <MdRedo
-        css={styles.icon}
+        css={[
+          styles.icon,
+          ...(!historyState?.future.length ? [styles.disabled] : []),
+        ]}
         size={24}
         onClick={() => {
           if (fileEntryId) history.redo(fileEntryId)
@@ -54,6 +61,9 @@ const styles = {
     &:hover {
       color: white;
     }
+  `,
+  disabled: css`
+    pointer-events: none;
   `,
 }
 

--- a/web/src/features/menu-bar/components/EditorMenu.tsx
+++ b/web/src/features/menu-bar/components/EditorMenu.tsx
@@ -2,10 +2,13 @@
 import { jsx, css } from '@emotion/core'
 import { MdBrush, MdUndo, MdRedo, MdTranslate } from 'react-icons/md'
 import { FaEraser } from 'react-icons/fa'
-import { useEditor } from '~/store/modules/editor'
+import { useEditor, useEditorState } from '~/store/modules/editor'
+import { useHistory } from '~/store/modules/history'
 
 const EditorMenu: React.FC = () => {
   const editor = useEditor()
+  const { fileEntryId } = useEditorState()
+  const history = useHistory()
 
   return (
     <div css={styles.editorMenu}>
@@ -20,8 +23,20 @@ const EditorMenu: React.FC = () => {
         onClick={() => editor.changeMode('erase')}
       />
       <MdTranslate css={styles.icon} size={24} />
-      <MdUndo css={styles.icon} size={24} />
-      <MdRedo css={styles.icon} size={24} />
+      <MdUndo
+        css={styles.icon}
+        size={24}
+        onClick={() => {
+          if (fileEntryId) history.undo(fileEntryId)
+        }}
+      />
+      <MdRedo
+        css={styles.icon}
+        size={24}
+        onClick={() => {
+          if (fileEntryId) history.redo(fileEntryId)
+        }}
+      />
     </div>
   )
 }

--- a/web/src/store/modules/history/actions.ts
+++ b/web/src/store/modules/history/actions.ts
@@ -14,7 +14,11 @@ export const redo = createAction('history/REDO_HISTORY')<RedoHistoryParams>()
 
 type RecordHistoryParams = {
   fileEntryId: string
-  data: string
+  data: {
+    points: number[]
+    stroke: string
+    strokeWidth: number
+  }
   type: HistoryType
 }
 export const record = createAction('history/RECORD_HISTORY')<

--- a/web/src/store/modules/history/actions.ts
+++ b/web/src/store/modules/history/actions.ts
@@ -1,0 +1,22 @@
+import { createAction } from 'typesafe-actions'
+import { HistoryType } from './types'
+
+type InitializeHistoryParams = { fileEntryId: string }
+export const initializeImage = createAction('history/INITIALIZE_FILE_HISTORY')<
+  InitializeHistoryParams
+>()
+
+type UndoHistoryParams = { fileEntryId: string }
+export const undo = createAction('history/UNDO_HISTORY')<UndoHistoryParams>()
+
+type RedoHistoryParams = { fileEntryId: string }
+export const redo = createAction('history/REDO_HISTORY')<RedoHistoryParams>()
+
+type RecordHistoryParams = {
+  fileEntryId: string
+  data: string
+  type: HistoryType
+}
+export const record = createAction('history/RECORD_HISTORY')<
+  RecordHistoryParams
+>()

--- a/web/src/store/modules/history/hooks.ts
+++ b/web/src/store/modules/history/hooks.ts
@@ -1,0 +1,52 @@
+import { useCallback, useMemo } from 'react'
+import { useSelector, shallowEqual, useDispatch } from 'react-redux'
+import { HistoryState } from './reducer'
+import * as historyActions from './actions'
+
+export function useHistory() {
+  const dispatch = useDispatch()
+
+  const undo = useCallback(
+    (fileEntryId: string) => dispatch(historyActions.undo({ fileEntryId })),
+    [dispatch]
+  )
+
+  const redo = useCallback(
+    (fileEntryId: string) => dispatch(historyActions.redo({ fileEntryId })),
+    [dispatch]
+  )
+
+  const draw = useCallback(
+    (fileEntryId: string, data: string) =>
+      dispatch(
+        historyActions.record({
+          fileEntryId,
+          data,
+          type: 'draw',
+        })
+      ),
+    [dispatch]
+  )
+
+  const initialize = useCallback(
+    (fileEntryId: string) =>
+      dispatch(historyActions.initializeImage({ fileEntryId })),
+    [dispatch]
+  )
+
+  return useMemo(() => ({ undo, redo, draw, initialize }), [
+    undo,
+    redo,
+    draw,
+    initialize,
+  ])
+}
+
+export function useHistoryState(fileEntryId: string | null) {
+  return useSelector(({ history }: { history: HistoryState }) => {
+    if (!fileEntryId) {
+      return undefined
+    }
+    return history[fileEntryId]
+  }, shallowEqual)
+}

--- a/web/src/store/modules/history/hooks.ts
+++ b/web/src/store/modules/history/hooks.ts
@@ -17,7 +17,10 @@ export function useHistory() {
   )
 
   const draw = useCallback(
-    (fileEntryId: string, data: string) =>
+    (
+      fileEntryId: string,
+      data: { points: number[]; stroke: string; strokeWidth: number }
+    ) =>
       dispatch(
         historyActions.record({
           fileEntryId,

--- a/web/src/store/modules/history/index.ts
+++ b/web/src/store/modules/history/index.ts
@@ -1,0 +1,9 @@
+import * as historyActions from './actions'
+import { ActionType } from 'typesafe-actions'
+
+export * from './actions'
+export * from './hooks'
+export * from './reducer'
+export * from './types'
+
+export type HistoryActions = ActionType<typeof historyActions>

--- a/web/src/store/modules/history/reducer.ts
+++ b/web/src/store/modules/history/reducer.ts
@@ -51,6 +51,8 @@ export const historyReducer = createReducer<HistoryState, HistoryActions>(
       if (fileHistoryObject.present)
         fileHistoryObject.past.push(fileHistoryObject.present)
 
+      fileHistoryObject.future = []
+
       fileHistoryObject.present = {
         type,
         data,

--- a/web/src/store/modules/history/reducer.ts
+++ b/web/src/store/modules/history/reducer.ts
@@ -16,6 +16,7 @@ export const historyReducer = createReducer<HistoryState, HistoryActions>(
   .handleAction(initializeImage, (state, { payload: { fileEntryId } }) =>
     produce(state, draft => {
       draft[fileEntryId] = {
+        lastAction: 'initialize',
         past: [],
         present: null,
         future: [],
@@ -29,6 +30,7 @@ export const historyReducer = createReducer<HistoryState, HistoryActions>(
 
       fileHistoryObject.future.unshift(fileHistoryObject.present)
       fileHistoryObject.present = fileHistoryObject.past.pop() || null
+      fileHistoryObject.lastAction = 'undo'
     })
   )
   .handleAction(redo, (state, { payload: { fileEntryId } }) =>
@@ -39,6 +41,7 @@ export const historyReducer = createReducer<HistoryState, HistoryActions>(
       if (fileHistoryObject.present)
         fileHistoryObject.past.push(fileHistoryObject.present)
       fileHistoryObject.present = fileHistoryObject.future.shift()!
+      fileHistoryObject.lastAction = 'redo'
     })
   )
   .handleAction(record, (state, { payload: { fileEntryId, data, type } }) =>
@@ -52,5 +55,6 @@ export const historyReducer = createReducer<HistoryState, HistoryActions>(
         type,
         data,
       }
+      fileHistoryObject.lastAction = 'record'
     })
   )

--- a/web/src/store/modules/history/reducer.ts
+++ b/web/src/store/modules/history/reducer.ts
@@ -1,0 +1,56 @@
+import produce from 'immer'
+import { createReducer } from 'typesafe-actions'
+import { HistoryActions } from '.'
+import { initializeImage, undo, redo, record } from './actions'
+import { HistoryObject } from './types'
+
+export interface HistoryState {
+  [fileEntryId: string]: HistoryObject
+}
+
+const initialState: HistoryState = {}
+
+export const historyReducer = createReducer<HistoryState, HistoryActions>(
+  initialState
+)
+  .handleAction(initializeImage, (state, { payload: { fileEntryId } }) =>
+    produce(state, draft => {
+      draft[fileEntryId] = {
+        past: [],
+        present: null,
+        future: [],
+      }
+    })
+  )
+  .handleAction(undo, (state, { payload: { fileEntryId } }) =>
+    produce(state, draft => {
+      const fileHistoryObject = draft[fileEntryId]
+      if (!fileHistoryObject.present) return
+
+      fileHistoryObject.future.unshift(fileHistoryObject.present)
+      fileHistoryObject.present = fileHistoryObject.past.pop() || null
+    })
+  )
+  .handleAction(redo, (state, { payload: { fileEntryId } }) =>
+    produce(state, draft => {
+      const fileHistoryObject = draft[fileEntryId]
+
+      if (!fileHistoryObject.future.length) return
+      if (fileHistoryObject.present)
+        fileHistoryObject.past.push(fileHistoryObject.present)
+      fileHistoryObject.present = fileHistoryObject.future.shift()!
+    })
+  )
+  .handleAction(record, (state, { payload: { fileEntryId, data, type } }) =>
+    produce(state, draft => {
+      const fileHistoryObject = draft[fileEntryId]
+
+      if (fileHistoryObject.present)
+        fileHistoryObject.past.push(fileHistoryObject.present)
+
+      fileHistoryObject.present = {
+        type,
+        data,
+      }
+    })
+  )

--- a/web/src/store/modules/history/types.ts
+++ b/web/src/store/modules/history/types.ts
@@ -1,12 +1,18 @@
 export type HistoryType = 'draw'
 
+export type Action = 'undo' | 'redo' | 'record' | 'initialize' | 'none'
+
 type HistoryData = {
   type: HistoryType
-  data: string
+  data: {
+    points: number[]
+    stroke: string
+    strokeWidth: number
+  }
 }
 
 export type HistoryObject = {
-  lastAction: 'undo' | 'redo' | 'record' | 'initialize' | 'none'
+  lastAction: Action
   past: HistoryData[]
   present: HistoryData | null
   future: HistoryData[]

--- a/web/src/store/modules/history/types.ts
+++ b/web/src/store/modules/history/types.ts
@@ -1,0 +1,12 @@
+export type HistoryType = 'draw'
+
+type HistoryData = {
+  type: HistoryType
+  data: string
+}
+
+export type HistoryObject = {
+  past: HistoryData[]
+  present: HistoryData | null
+  future: HistoryData[]
+}

--- a/web/src/store/modules/history/types.ts
+++ b/web/src/store/modules/history/types.ts
@@ -6,6 +6,7 @@ type HistoryData = {
 }
 
 export type HistoryObject = {
+  lastAction: 'undo' | 'redo' | 'record' | 'initialize' | 'none'
   past: HistoryData[]
   present: HistoryData | null
   future: HistoryData[]

--- a/web/src/store/rootReducer.ts
+++ b/web/src/store/rootReducer.ts
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux'
 import { editorReducer } from './modules/editor'
+import { historyReducer } from './modules/history'
 
 const rootReducer = combineReducers({
   editor: editorReducer,
+  history: historyReducer,
 })
 
 export default rootReducer


### PR DESCRIPTION
#16 이슈에서 나왔던 Undo, Redo 기능을 redux를 사용해서 저장하는 방식으로 제작했습니다.
추후 다양한 타입의 히스토리를 저장하기 위한 조정이 필요할 것 같습니다.